### PR TITLE
Handle failed rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Imports
 A plugin for importing content into Janeway.
 
+# Installation instructions
+ - Clone the project onto the plugins path of your janeway installation ('/path/to/janeway/src/plugins')
+
+
+## Importers with a web interface
+ - Editorial team import (from CSV file)
+ - Reviewer database import (from CSV file)
+ - Article metadata (from CSV file)
+ - Article images (from CSV file)
+ - Wordpress news items
+
+This importers can be accesed from the janeway journal manager under the path `/plugins/imports`
+
+
 # Requirements
 In addition to the base Janeway requirements this plugin needs `python-wordpress-xmlrpc` version 2.3.
 

--- a/jats.py
+++ b/jats.py
@@ -41,6 +41,7 @@ def import_jats_article(jats_contents, journal, persist=True, filename=None, own
     meta["keywords"] = get_jats_keywords(metadata_soup)
     meta["section_name"] = get_jats_section_name(jats_soup)
     meta["date_published"] = get_jats_pub_date(jats_soup) or datetime.date.today()
+    meta["authors"] = []
     meta["date_submitted"] = None
     meta["date_accepted"] = None
     history_soup = metadata_soup.find("history")

--- a/templates/import/editorial_import.html
+++ b/templates/import/editorial_import.html
@@ -10,6 +10,21 @@
 
 {% block body %}
 
+    {% if errors %}
+    <div class="box">
+        <div class="title-area">
+            <h2>Errors found</h2>
+        </div>
+            {% if error_file %}
+                <p><a class="button alert" href="{% url 'imports_failed_rows' error_file %}"><span class="fa fa-download"></span> Download CSV with failed rows</a></p>
+            {% endif %}
+              {% for line_no, error in errors.items %}
+              <div class="callout alert"><p>Line {{ line_no }}: {{ error }}</p></div>
+              {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
     <div class="box">
         <div class="title-area">
             <h2>Processing {{ filename }}</h2>
@@ -18,10 +33,12 @@
             <table>
                 {% include "import/reader_element.html" with reader=reader %}
             </table>
+            {% if not errors %}
             <form method="POST">
                 {% csrf_token %}
                 <button name="submit" class="button">Import</button>
             </form>
+            {% endif %}
         </div>
     </div>
 

--- a/urls.py
+++ b/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
         name='wordpress_posts'),
 
     url(r'^example_csv/$', views.csv_example, name='imports_csv_example'),
+    url(r'^failed_rows/(?P<tmp_file_name>[.0-9a-z-]+)$', views.serve_failed_rows, name='imports_failed_rows'),
 ]


### PR DESCRIPTION
Allows the metadata import job to run even if some rows fail to process.
At the end of the import job, failing rows and messages are returned to the user, as well as an option to download a csv of just the failed rows
