### PR TITLE
Allow importing editors via CSV

### DIFF
--- a/templates/import/editorial_load.html
+++ b/templates/import/editorial_load.html
@@ -21,11 +21,18 @@
                 {% include "import/contacts_description.html" %}
             {% elif type == 'reviewers' %}
                 {% include "import/reviewers_description.html" %}
+            {% elif type == 'editors' %}
+                {% include "import/editors_description.html" %}
             {% endif %}
 
             <form method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <input type="file" name="file">
+                {% if type == 'editors' or type == 'reviewers' %}
+                <br>
+                <input type="checkbox" name="reset-passwords" id="reset-passwords"> <label for="reset-passwords" class="toggle">Reset users' passwords (they will receive a password reset email) </label>
+                <br>
+                {% endif %}
                 <button class="button"><i class="fa fa-upload"></i> Upload</button>
             </form>
 

--- a/templates/import/editors_description.html
+++ b/templates/import/editors_description.html
@@ -1,0 +1,6 @@
+<p>This import script allows you to import your pool of editors from a CSV file with the following structure:</p>
+<p>Salutation, firstname, middlename, lastname, email_address, department, institution, country, reviewer interests</p>
+<p>If the user is not in the system yet, you can toggle the flag below to start the password reset process process automatically for all users.</p>
+<div class="callout  bs-callout-warning alert alert-warning" role="alert">Even when using the automatic password reset process, it is important to let your reviewers know ahead of time.</div>
+<p>Here is an example line from a dummy csv:<br/>
+    <pre>Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK,'Humanities;Open Access'</pre></p>

--- a/templates/import/index.html
+++ b/templates/import/index.html
@@ -20,8 +20,10 @@
                 <li class="accordion-item" data-accordion-item>
                     <a href="#" class="accordion-title">Editorial Team Import</a>
                     <div class="accordion-content" data-tab-content>
-                        <p>This import script allows you to pull in your editorial team from a CSV file. It should have
-                            the following format:</p>
+                        <p>This import script allows you to pull in your editorial team from a CSV file.
+                            It is meant to be used for populating the editorial team page of the journal but it does
+                            not grant any roles. For that, see the 'Editors Import' menu below.
+                            It should have the following format:</p>
                         <p>salutation, firstname, middlename, lastname, email_address, department, institution, country</p>
                         <p>Here is an example line from a dummy csv:<br/>
                             Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK</p>
@@ -34,8 +36,18 @@
                         <p>This import script allows you to import your pool of reviewers from a CSV file with the following structure:</p>
                         <p>Salutation firstname, middlename, lastname, email_address, department, institution, country</p>
                         <p>Here is an example line from a dummy csv:<br/>
-                            Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK</p>
+                            Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK,'Humanities; Open Access'</p>
                         <a href="{% url 'imports_load' %}?type=reviewers" class="button">Start Import</a>
+                    </div>
+                </li>
+                <li class="accordion-item" data-accordion-item>
+                    <a href="#" class="accordion-title">Editors Import</a>
+                    <div class="accordion-content" data-tab-content>
+                        <p>This import script allows you to import your pool of editors from a CSV file with the following structure:</p>
+                        <p>Salutation firstname, middlename, lastname, email_address, department, institution, country</p>
+                        <p>Here is an example line from a dummy csv:<br/>
+                            Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK</p>
+                        <a href="{% url 'imports_load' %}?type=editors" class="button">Start Import</a>
                     </div>
                 </li>
 

--- a/templates/import/reviewers_description.html
+++ b/templates/import/reviewers_description.html
@@ -1,5 +1,6 @@
 <p>This import script allows you to import your pool of reviewers from a CSV file with the following structure:</p>
-<p>Salutation, firstname, middlename, lastname, email_address, department, institution, country</p>
-<p>If the user is not in the system yet they will be sent an email to reset their account's password</p>
+<p>Salutation, firstname, middlename, lastname, email_address, department, institution, country, reviewer interests</p>
+<p>If the user is not in the system yet, you can toggle the flag below to start the review process automatically for all users.</p>
+<div class="callout  bs-callout-warning alert alert-warning" role="alert">Even when using the automatic password reset process, it is important to let your reviewers know ahead of time.</div>
 <p>Here is an example line from a dummy csv:<br/>
-    Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK</p>
+    <pre>Prof, Martin,Paul,Eve,mpeve@voyager.com,Science,USS Voyager,UK,'Humanities;Open Access'</pre></p>

--- a/utils.py
+++ b/utils.py
@@ -125,6 +125,16 @@ def import_user(request, row, reset_pwd=False):
     )
     if created and reset_pwd:
         core_logic.start_reset_process(request, user)
+    try:
+        review_interests = row[8]
+        re.split('[,;]+', review_interests)
+    except (IndexError, AttributeError):
+        review_interests = []
+
+    for term in review_interests:
+        interest, _ = core_models.Interest.objects.get_or_create(name=term)
+        user.interest.add(interest)
+
 
     return user, created
 

--- a/utils.py
+++ b/utils.py
@@ -97,14 +97,21 @@ def import_reviewers(request, reader):
         if not user.is_reviewer(request):
             user.add_account_role('reviewer', request.journal)
 
+def import_editors(request, reader):
+    row_list = [row for row in reader]
+    row_list.remove(row_list[0])
+
+    for row in row_list:
+        user, _ = import_user(request, row, reset_pwd=True)
+        if not user.is_editor(request):
+            user.add_account_role('editor', request.journal)
 
 def import_user(request, row, reset_pwd=False):
     try:
         country = core_models.Country.objects.get(code=row[7])
     except core_models.Country.DoesNotExist:
         country = None
-    user, created = core_models.Account.objects.get_or_create(
-        username=row[4],
+    user, created = core_models.Account.objects.update_or_create(
         email=row[4],
         defaults={
             'salutation': row[0],

--- a/utils.py
+++ b/utils.py
@@ -91,9 +91,12 @@ def import_editorial_team(request, reader):
 def import_reviewers(request, reader):
     row_list = [row for row in reader]
     row_list.remove(row_list[0])
+    reset_pwd = False
 
     for row in row_list:
-        user, _ = import_user(request, row, reset_pwd=True)
+        if "reset-passwords" in request.POST:
+            reset_pwd = True
+        user, _ = import_user(request, row, reset_pwd=reset_pwd)
         if not user.is_reviewer(request):
             user.add_account_role('reviewer', request.journal)
 

--- a/views.py
+++ b/views.py
@@ -115,10 +115,13 @@ def import_action(request, filename):
         reader = csv.reader(file)
 
     if request.POST:
+        import pdb;pdb.set_trace()
         if request_type == 'editorial':
             utils.import_editorial_team(request, reader)
-        if request_type == 'reviewers':
+        elif request_type == 'reviewers':
             utils.import_reviewers(request, reader)
+        elif request_type == 'editors':
+            utils.import_editors(request, reader)
         elif request_type == 'contacts':
             utils.import_contacts_team(request, reader)
         elif request_type == 'submission':


### PR DESCRIPTION
Bonus:
 - User imports via CSV now can take in review interests.
 - When running a user import, the editor can optionally initiate a password reset for all of them.