### PR TITLE
fix: update snapshot method to snapshot_as_author for consistency

### DIFF
--- a/mediacommons.py
+++ b/mediacommons.py
@@ -284,7 +284,7 @@ def import_review_data(article, review_data):
 def import_author(article, author_data, idx):
         author = update_or_create_account(author_data)
         author.add_account_role("author", article.journal)
-        author.snapshot_self(article)
+        author.snapshot_as_author(article)
 
 def make_xml_galley(article, owner, data):
     for galley in article.galley_set.all():

--- a/ojs/ojs3_importers.py
+++ b/ojs/ojs3_importers.py
@@ -195,7 +195,7 @@ def import_author_assignments(article, article_dict):
         try:
             account = models.OJSAccount.objects.get(
                 ojs_id=author_id, journal=article.journal).account
-            account.snapshot_self(article)
+            account.snapshot_as_author(article)
             if i == 0:
                 article.owner = account
                 article.correspondence_author = account

--- a/utils.py
+++ b/utils.py
@@ -910,7 +910,7 @@ def import_author(author_fields, article):
         author.orcid = orcid_from_url(orcid)
 
     author.save()
-    author.snapshot_self(article)
+    author.snapshot_as_author(article)
     article.save()
     frozen_author = update_frozen_author(author, author_fields, article)
     return author, frozen_author


### PR DESCRIPTION
Fixes issue error on article import: "Use snapshot_as_author instead" #115

Found the reference to "snapshot_self" was deprecated. 